### PR TITLE
fix org image for iris agent

### DIFF
--- a/src/data/leaderboard.json
+++ b/src/data/leaderboard.json
@@ -7,7 +7,7 @@
             "score": 58.12,
             "steps": "N/A",
             "costs": "N/A",
-            "org": "https://github.com/user-attachments/assets/6a48b1d6-a73c-4520-8a84-91a0750bffc3",
+            "org": "https://github.com/user-attachments/assets/2a88e1e7-c765-4f2b-bede-0cd955b290d7",
             "date": "2026-06-25",
             "enviroment_model": "GPT-5.4",
             "trajs": "✓",


### PR DESCRIPTION
### Description
The previous logo URL for `IRIS-Agent` was broken/not visible due to permission restrictions (404 for other users). 

This PR updates the `"org"` field in `leaderboard.json` with a newly uploaded, publicly accessible image URL to ensure the logo displays correctly on the leaderboard.

Thanks.

<img width="500" height="281" alt="iris-agent" src="https://github.com/user-attachments/assets/2a88e1e7-c765-4f2b-bede-0cd955b290d7" />